### PR TITLE
Docker go image updated

### DIFF
--- a/.Dockerfile
+++ b/.Dockerfile
@@ -1,5 +1,5 @@
 # Usa la imagen oficial de Golang como base
-FROM golang:1.20
+FROM golang:1.20-alpine
 
 # Establece el directorio de trabajo en /app
 WORKDIR /

--- a/cmd/adapters/entrypoints/handlers/user/entities.go
+++ b/cmd/adapters/entrypoints/handlers/user/entities.go
@@ -6,8 +6,8 @@ type LoginRequest struct {
 }
 
 type CreateUserRequest struct {
-	UserName string
-	Password string
+	UserName string `json:"username" required:"true"`
+	Password string `json:"password" required:"true"`
 	Name     string
 	LastName string
 	DNI      string

--- a/cmd/adapters/entrypoints/handlers/user/entities.go
+++ b/cmd/adapters/entrypoints/handlers/user/entities.go
@@ -6,8 +6,8 @@ type LoginRequest struct {
 }
 
 type CreateUserRequest struct {
-	UserName string 
-	Password string 
+	UserName string
+	Password string
 	Name     string
 	LastName string
 	DNI      string

--- a/cmd/adapters/entrypoints/handlers/user/entities.go
+++ b/cmd/adapters/entrypoints/handlers/user/entities.go
@@ -6,8 +6,8 @@ type LoginRequest struct {
 }
 
 type CreateUserRequest struct {
-	UserName string `json:"username" required:"true"`
-	Password string `json:"password" required:"true"`
+	UserName string 
+	Password string 
 	Name     string
 	LastName string
 	DNI      string


### PR DESCRIPTION
Se cambia la imagen de Go de docker para que la imagen pese menos ya que antes pesaba casi 1 gb y ahora 300 mb 

![image](https://github.com/fedeveron01/factory-management-system-backend/assets/44122805/cd0a424e-d518-4bdc-a7b4-241967e20676)

![image](https://github.com/fedeveron01/factory-management-system-backend/assets/44122805/98dbcf1e-c93c-4067-b440-a76c45397496)
