### PR TITLE
FIX getByType Material

### DIFF
--- a/cmd/adapters/entrypoints/handlers/movement/handlers.go
+++ b/cmd/adapters/entrypoints/handlers/movement/handlers.go
@@ -46,9 +46,9 @@ func (p *MovementHandler) GetAll(w http.ResponseWriter, r *http.Request) {
 
 // GetAll Handle api/movement GET request
 func (p *MovementHandler) GetAllByType(w http.ResponseWriter, r *http.Request) {
-	var movementRequestByType MovementRequestByType
-	err := json.NewDecoder(r.Body).Decode(&movementRequestByType)
-	movements, err := p.movementUseCase.FindAllByType(movementRequestByType.IsInput)
+	vars := mux.Vars(r)
+	typeValue := vars["type"]
+	movements, err := p.movementUseCase.FindAllByType(typeValue)
 	if err != nil {
 		p.WriteErrorResponse(w, err)
 	}

--- a/cmd/adapters/gateways/movement_gateway.go
+++ b/cmd/adapters/gateways/movement_gateway.go
@@ -11,14 +11,14 @@ import (
 type MovementRepository interface {
 	CreateMovement(movement gateway_entities.Movement) (gateway_entities.Movement, error)
 	FindAll() ([]gateway_entities.Movement, error)
-	FindAllByType(isInput bool) ([]gateway_entities.Movement, error)
+	FindAllByType(typeValue string) ([]gateway_entities.Movement, error)
 	FindById(id uint) (gateway_entities.Movement, error)
 }
 
 type MovementGateway interface {
 	Create(movement entities.Movement) (entities.Movement, error)
 	FindAll() ([]entities.Movement, error)
-	FindAllByType(isInput bool) ([]entities.Movement, error)
+	FindAllByType(typeValue string) ([]entities.Movement, error)
 	FindById(id uint) (entities.Movement, error)
 }
 
@@ -44,8 +44,8 @@ func (i *MovementGatewayImpl) FindAll() ([]entities.Movement, error) {
 	return movements, nil
 }
 
-func (i *MovementGatewayImpl) FindAllByType(isInput bool) ([]entities.Movement, error) {
-	movementsDB, err := i.movementRepository.FindAllByType(isInput)
+func (i *MovementGatewayImpl) FindAllByType(typeValue string) ([]entities.Movement, error) {
+	movementsDB, err := i.movementRepository.FindAllByType(typeValue)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/api/mapping.go
+++ b/cmd/api/mapping.go
@@ -29,7 +29,7 @@ func ConfigureMappings(app mux.Router, handlers infrastructure.HandlerContainer)
 
 	//movement
 	app.HandleFunc("/api/movement", handlers.MovementHandler.GetAll).Methods("GET")
-	app.HandleFunc("/api/movementByType", handlers.MovementHandler.GetAllByType).Methods("GET")
+	app.HandleFunc("/api/movement/{type}", handlers.MovementHandler.GetAllByType).Methods("GET")
 	app.HandleFunc("/api/movement/{id}", handlers.MovementHandler.GetById).Methods("GET")
 	/*app.HandleFunc("/api/movement", handlers.MovementHandler.Create).Methods("POST")
 	app.HandleFunc("/api/movement", handlers.MovementHandler.Update).Methods("PUT")*/

--- a/cmd/repositories/movement.go
+++ b/cmd/repositories/movement.go
@@ -33,14 +33,8 @@ func (r *MovementRepository) FindAll() ([]gateway_entities.Movement, error) {
 	return movements, nil
 }
 
-func (r *MovementRepository) FindAllByType(isInput bool) ([]gateway_entities.Movement, error) {
+func (r *MovementRepository) FindAllByType(typeValue string) ([]gateway_entities.Movement, error) {
 	var movements []gateway_entities.Movement
-	var typeValue = ""
-	if isInput {
-		typeValue = "input"
-	} else {
-		typeValue = "output"
-	}
 	result := r.db.Find(&movements, "type = ?", typeValue)
 	if result.Error != nil {
 		return nil, result.Error

--- a/cmd/usecases/movement/movement_usecase.go
+++ b/cmd/usecases/movement/movement_usecase.go
@@ -9,14 +9,14 @@ import (
 
 type MovementUseCase interface {
 	Create(movement entities.Movement, employeeId uint) (entities.Movement, error)
-	FindAllByType(isInput bool) ([]entities.Movement, error)
+	FindAllByType(typeValue string) ([]entities.Movement, error)
 	FindAll() ([]entities.Movement, error)
 	FindById(id uint) (entities.Movement, error)
 }
 
 type MovementGateway interface {
 	Create(movement entities.Movement, employeeID uint) (entities.Movement, error)
-	FindAllByType(isInput bool) ([]entities.Movement, error)
+	FindAllByType(typeValue string) ([]entities.Movement, error)
 	FindAll() ([]entities.Movement, error)
 	FindById(id uint) (entities.Movement, error)
 }
@@ -42,8 +42,8 @@ func NewMovementUseCase(movementGateway MovementGateway, movementDetailGateway M
 	}
 }
 
-func (i *MovementUseCaseImpl) FindAllByType(isInput bool) ([]entities.Movement, error) {
-	movements, err := i.movementGateway.FindAllByType(isInput)
+func (i *MovementUseCaseImpl) FindAllByType(typeValue string) ([]entities.Movement, error) {
+	movements, err := i.movementGateway.FindAllByType(typeValue)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Ahora el  endpoit /api/movementByType  es   /api/movement/{type} 

ya no se recibe un body con booleano sino que se envia por path el tipo requerido mediante texto.

![image](https://github.com/fedeveron01/factory-management-system-backend/assets/80277100/9f68d260-9564-41d0-8ec4-2a497849e2a7)

